### PR TITLE
Add account Id to client.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <name>Salesforce Marketing plugins</name>
   <groupId>io.cdap.plugin</groupId>
   <artifactId>salesforce-marketing-plugins</artifactId>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.2.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
 

--- a/src/main/java/io/cdap/plugin/sfmc/sink/DataExtensionClient.java
+++ b/src/main/java/io/cdap/plugin/sfmc/sink/DataExtensionClient.java
@@ -59,13 +59,16 @@ public class DataExtensionClient {
     this.dataExtensionKey = dataExtensionKey;
   }
 
-  public static DataExtensionClient create(String dataExtensionKey, String clientId, String clientSecret,
-                                           String authEndpoint, String soapEndpoint) throws ETSdkException {
+  public static DataExtensionClient create(String dataExtensionKey, String clientId,
+                                           String clientSecret,
+                                           String authEndpoint, String soapEndpoint,
+                                           String accountId) throws ETSdkException {
     ETConfiguration conf = new ETConfiguration();
     conf.set("clientId", clientId);
     conf.set("clientSecret", clientSecret);
     conf.set("authEndpoint", authEndpoint);
     conf.set("soapEndpoint", soapEndpoint);
+    conf.set("accountId", accountId);
     conf.set("useOAuth2Authentication", "true");
     ClassLoader oldCL = Thread.currentThread().getContextClassLoader();
     try {

--- a/src/main/java/io/cdap/plugin/sfmc/sink/DataExtensionOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/sfmc/sink/DataExtensionOutputFormat.java
@@ -36,6 +36,7 @@ public class DataExtensionOutputFormat extends OutputFormat<NullWritable, Struct
   public static final String CLIENT_SECRET = "cdap.sfmc.client.secret";
   public static final String AUTH_ENDPOINT = "cdap.sfmc.auth.endpoint";
   public static final String SOAP_ENDPOINT = "cdap.sfmc.soap.endpoint";
+  public static final String ACCOUNT_ID = "cdap.sfmc.account.id";
   public static final String DATA_EXTENSION_KEY = "cdap.sfmc.data.extension.key";
   public static final String MAX_BATCH_SIZE = "cdap.sfmc.max.batch.size";
   public static final String FAIL_ON_ERROR = "cdap.sfmc.fail.on.error";
@@ -49,6 +50,7 @@ public class DataExtensionOutputFormat extends OutputFormat<NullWritable, Struct
     String clientSecret = getOrError(conf, CLIENT_SECRET);
     String authEndpoint = getOrError(conf, AUTH_ENDPOINT);
     String soapEndpoint = getOrError(conf, SOAP_ENDPOINT);
+    String accountId = getOrError(conf, ACCOUNT_ID);
     String dataExtensionKey = getOrError(conf, DATA_EXTENSION_KEY);
     Operation operation = Operation.valueOf(getOrError(conf, OPERATION));
     int maxBatchSize = Integer.parseInt(getOrError(conf, MAX_BATCH_SIZE));
@@ -56,7 +58,7 @@ public class DataExtensionOutputFormat extends OutputFormat<NullWritable, Struct
     boolean shouldTruncate = Boolean.parseBoolean(getOrError(conf, TRUNCATE));
     try {
       DataExtensionClient client = DataExtensionClient.create(dataExtensionKey, clientId, clientSecret,
-                                                              authEndpoint, soapEndpoint);
+                                                              authEndpoint, soapEndpoint, accountId);
       RecordDataExtensionRowConverter converter = new RecordDataExtensionRowConverter(client.getDataExtensionInfo(),
                                                                                       shouldTruncate);
       return new DataExtensionRecordWriter(client, converter, operation, maxBatchSize, failOnError);

--- a/src/main/java/io/cdap/plugin/sfmc/sink/MarketingCloudConf.java
+++ b/src/main/java/io/cdap/plugin/sfmc/sink/MarketingCloudConf.java
@@ -40,6 +40,7 @@ public class MarketingCloudConf extends PluginConfig {
   public static final String DATA_EXTENSION = "dataExtension";
   public static final String AUTH_ENDPOINT = "authEndpoint";
   public static final String SOAP_ENDPOINT = "soapEndpoint";
+  public static final String ACCOUNT_ID = "accountId";
   public static final String BATCH_SIZE = "maxBatchSize";
   public static final String FAIL_ON_ERROR = "failOnError";
   public static final String OPERATION = "operation";
@@ -74,6 +75,11 @@ public class MarketingCloudConf extends PluginConfig {
   @Name(SOAP_ENDPOINT)
   @Description("Endpoint to use when communicating with the Marketing Cloud SOAP API.")
   private String soapEndpoint;
+
+  @Macro
+  @Name(ACCOUNT_ID)
+  @Description("Account ID to use when communicating with the Marketing Cloud SOAP API.")
+  private String accountId;
 
   @Macro
   @Nullable
@@ -135,6 +141,10 @@ public class MarketingCloudConf extends PluginConfig {
     return soapEndpoint;
   }
 
+  String getAccountId() {
+    return accountId;
+  }
+
   int getMaxBatchSize() {
     return maxBatchSize == null ? 500 : maxBatchSize;
   }
@@ -194,10 +204,10 @@ public class MarketingCloudConf extends PluginConfig {
       return;
     }
     if (!containsMacro(CLIENT_ID) && !containsMacro(CLIENT_SECRET) && !containsMacro(DATA_EXTENSION) &&
-      !containsMacro(AUTH_ENDPOINT) && !containsMacro(SOAP_ENDPOINT)) {
+      !containsMacro(AUTH_ENDPOINT) && !containsMacro(SOAP_ENDPOINT) && !containsMacro(ACCOUNT_ID)) {
       try {
         DataExtensionClient client = DataExtensionClient.create(dataExtension, clientId, clientSecret,
-                                                                authEndpoint, soapEndpoint);
+                                                                authEndpoint, soapEndpoint, accountId);
         client.validateSchemaCompatibility(inputSchema, collector);
       } catch (ETSdkException e) {
         collector.addFailure("Error while validating Marketing Cloud client: " + e.getMessage(), null)

--- a/src/main/java/io/cdap/plugin/sfmc/source/MarketingCloudClient.java
+++ b/src/main/java/io/cdap/plugin/sfmc/source/MarketingCloudClient.java
@@ -59,12 +59,13 @@ public class MarketingCloudClient {
    * @throws ETSdkException The FuelSDKException
    */
   public static MarketingCloudClient create(String clientId, String clientSecret, String authEndpoint,
-                                            String soapEndpoint) throws ETSdkException {
+                                            String soapEndpoint, String accountId) throws ETSdkException {
     ETConfiguration conf = new ETConfiguration();
     conf.set("clientId", clientId);
     conf.set("clientSecret", clientSecret);
     conf.set("authEndpoint", authEndpoint);
     conf.set("soapEndpoint", soapEndpoint);
+    conf.set("accountId", accountId);
     conf.set("useOAuth2Authentication", "true");
     ClassLoader oldCL = Thread.currentThread().getContextClassLoader();
     try {

--- a/src/main/java/io/cdap/plugin/sfmc/source/MarketingCloudInputFormat.java
+++ b/src/main/java/io/cdap/plugin/sfmc/source/MarketingCloudInputFormat.java
@@ -74,7 +74,8 @@ public class MarketingCloudInputFormat extends InputFormat<NullWritable, Structu
   private static List<MarketingCloudObjectInfo> fetchTableInfo(SourceQueryMode mode, MarketingCloudSourceConfig conf) {
     try {
       MarketingCloudClient client = MarketingCloudClient.create(conf.getClientId(), conf.getClientSecret(),
-                                                                conf.getAuthEndpoint(), conf.getSoapEndpoint());
+                                                                conf.getAuthEndpoint(), conf.getSoapEndpoint(),
+                                                                conf.getAccountId());
 
       //When mode = SingleObject, fetch fields for the object selected in plugin config
       if (mode == SourceQueryMode.SINGLE_OBJECT) {

--- a/src/main/java/io/cdap/plugin/sfmc/source/MarketingCloudRecordReader.java
+++ b/src/main/java/io/cdap/plugin/sfmc/source/MarketingCloudRecordReader.java
@@ -138,7 +138,8 @@ public class MarketingCloudRecordReader extends RecordReader<NullWritable, Struc
 
     MarketingCloudClient client = MarketingCloudClient.create(pluginConf.getClientId(), pluginConf.getClientSecret(),
                                                               pluginConf.getAuthEndpoint(),
-                                                              pluginConf.getSoapEndpoint());
+                                                              pluginConf.getSoapEndpoint(),
+                                                              pluginConf.getAccountId());
     //Fetch data
     if (object == SourceObject.DATA_EXTENSION) {
       results = client.fetchDataExtensionRecords(dataExtensionKey, object.getFilter());

--- a/src/main/java/io/cdap/plugin/sfmc/source/MarketingCloudSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/sfmc/source/MarketingCloudSourceConfig.java
@@ -136,27 +136,38 @@ public class MarketingCloudSourceConfig extends PluginConfig {
     "For example, https://instance.soap.marketingcloudapis.com/Service.asmx")
   private String soapEndpoint;
 
+  @Name(MarketingCloudConstants.PROPERTY_ACCOUNT_ID)
+  @Macro
+  @Description("The account Id")
+  private String accountId;
+
   /**
    * Constructor for MarketingCloudSourceConfig object.
    *
    * @param referenceName     The reference name
    * @param queryMode         The query mode
-   * @param objectName        The object name to be fetched from Salesforce Marketing Cloud
-   * @param dataExtensionKey  The data extension key to be fetched from Salesforce Marketing Cloud
-   * @param objectList        The list of objects to be fetched from Salesforce Marketing Cloud
-   * @param dataExtensionKeys The list of data extension keys to be fetched from Salesforce Marketing Cloud
+   * @param objectName        The object name to be fetched from Salesforce
+   *                          Marketing Cloud
+   * @param dataExtensionKey  The data extension key to be fetched from Salesforce
+   *                          Marketing Cloud
+   * @param objectList        The list of objects to be fetched from Salesforce
+   *                          Marketing Cloud
+   * @param dataExtensionKeys The list of data extension keys to be fetched from
+   *                          Salesforce Marketing Cloud
    * @param tableNameField    The field name to hold the table name value
    * @param clientId          The Salesforce Marketing Cloud Client Id
    * @param clientSecret      The Salesforce Marketing Cloud Client Secret
    * @param restEndpoint      The REST API endpoint for Salesforce Marketing Cloud
    * @param authEndpoint      The AUTH API endpoint for Salesforce Marketing Cloud
    * @param soapEndpoint      The SOAP API endpoint for Salesforce Marketing Cloud
+   * @param accountId         The account id for Salesforce Marketing Cloud
    */
   public MarketingCloudSourceConfig(String referenceName, String queryMode, @Nullable String objectName,
                                     @Nullable String dataExtensionKey, @Nullable String objectList,
                                     @Nullable String dataExtensionKeys, @Nullable String tableNameField,
                                     @Nullable String filter, String clientId, String clientSecret,
-                                    String restEndpoint, String authEndpoint, String soapEndpoint) {
+      String restEndpoint, String authEndpoint, String soapEndpoint,
+                                    String accountId) {
     this.referenceName = referenceName;
     this.queryMode = queryMode;
     this.objectName = objectName;
@@ -170,7 +181,7 @@ public class MarketingCloudSourceConfig extends PluginConfig {
     this.restEndpoint = restEndpoint;
     this.authEndpoint = authEndpoint;
     this.soapEndpoint = soapEndpoint;
-
+    this.accountId = accountId;
   }
 
   public String getReferenceName() {
@@ -316,6 +327,9 @@ public class MarketingCloudSourceConfig extends PluginConfig {
     return soapEndpoint;
   }
 
+  public String getAccountId() {
+    return accountId;
+  }
 
   /**
    * Validates {@link MarketingCloudSourceConfig} instance.
@@ -377,7 +391,7 @@ public class MarketingCloudSourceConfig extends PluginConfig {
   @VisibleForTesting
   void validateSalesforceConnection(FailureCollector collector) {
     try {
-      MarketingCloudClient.create(clientId, clientSecret, authEndpoint, soapEndpoint);
+      MarketingCloudClient.create(clientId, clientSecret, authEndpoint, soapEndpoint, accountId);
     } catch (ETSdkException e) {
       collector.addFailure("Unable to connect to Salesforce Instance.",
                            "Ensure properties like Client ID, Client Secret, API Endpoint " +

--- a/src/main/java/io/cdap/plugin/sfmc/source/util/MarketingCloudConstants.java
+++ b/src/main/java/io/cdap/plugin/sfmc/source/util/MarketingCloudConstants.java
@@ -82,6 +82,11 @@ public interface MarketingCloudConstants {
   String PROPERTY_SOAP_API_ENDPOINT = "soapEndpoint";
 
   /**
+   * Configuration property name used to specify account id.
+   */
+  String PROPERTY_ACCOUNT_ID = "accountId";
+
+  /**
    * Table prefix to be used in case of Multi-Object support.
    */
   String TABLE_PREFIX = "multisink.";

--- a/src/test/java/io/cdap/plugin/sfmc/source/SalesforceSourceConfigHelper.java
+++ b/src/test/java/io/cdap/plugin/sfmc/source/SalesforceSourceConfigHelper.java
@@ -27,6 +27,7 @@ public class SalesforceSourceConfigHelper {
   public static final String TEST_REST_ENDPOINT = "TestRestEndpoint";
   public static final String TEST_AUTH_ENDPOINT = "TestAuthEndpoint";
   public static final String TEST_SOAP_ENDPOINT = "TestSoapEndpoint";
+  public static final String TEST_ACCOUNT_ID = "TestAccountId";
   public static final String TEST_OBJECT_NAME = "Data Extension";
   public static final String TEST_OBJECT_LIST = "Data Extension";
   private static final String TEST_FILTER = "";
@@ -42,6 +43,7 @@ public class SalesforceSourceConfigHelper {
     private String restEndpoint = TEST_REST_ENDPOINT;
     private String authEndpoint = TEST_AUTH_ENDPOINT;
     private String soapEndpoint = TEST_SOAP_ENDPOINT;
+    private String accountId = TEST_ACCOUNT_ID;
     private String queryMode;
     private String objectName = TEST_OBJECT_NAME;
     private String filter = TEST_FILTER;
@@ -115,10 +117,15 @@ public class SalesforceSourceConfigHelper {
       return this;
     }
 
+    public ConfigBuilder setAccountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
     public MarketingCloudSourceConfig build() {
       return new MarketingCloudSourceConfig(referenceName, queryMode, objectName, dataExtensionKey, objectList,
                                             dataExtensionKeys, tableNameField, filter, clientId, clientSecret,
-                                            restEndpoint, authEndpoint, soapEndpoint);
+                                            restEndpoint, authEndpoint, soapEndpoint, accountId);
     }
   }
 }

--- a/src/test/java/io/cdap/plugin/sfmc/source/SalesforceSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/sfmc/source/SalesforceSourceConfigTest.java
@@ -28,11 +28,13 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
+import static io.cdap.plugin.sfmc.source.SalesforceSourceConfigHelper.TEST_ACCOUNT_ID;
 import static io.cdap.plugin.sfmc.source.SalesforceSourceConfigHelper.TEST_AUTH_ENDPOINT;
 import static io.cdap.plugin.sfmc.source.SalesforceSourceConfigHelper.TEST_CLIENT_ID;
 import static io.cdap.plugin.sfmc.source.SalesforceSourceConfigHelper.TEST_CLIENT_SECRET;
 import static io.cdap.plugin.sfmc.source.SalesforceSourceConfigHelper.TEST_REST_ENDPOINT;
 import static io.cdap.plugin.sfmc.source.SalesforceSourceConfigHelper.TEST_SOAP_ENDPOINT;
+import static io.cdap.plugin.sfmc.source.util.MarketingCloudConstants.PROPERTY_ACCOUNT_ID;
 import static io.cdap.plugin.sfmc.source.util.MarketingCloudConstants.PROPERTY_AUTH_API_ENDPOINT;
 import static io.cdap.plugin.sfmc.source.util.MarketingCloudConstants.PROPERTY_CLIENT_ID;
 import static io.cdap.plugin.sfmc.source.util.MarketingCloudConstants.PROPERTY_CLIENT_SECRET;
@@ -100,6 +102,7 @@ public class SalesforceSourceConfigTest {
       .setRestEndpoint(TEST_REST_ENDPOINT)
       .setAuthEndpoint(TEST_AUTH_ENDPOINT)
       .setSoapEndpoint(TEST_SOAP_ENDPOINT)
+      .setAccountId(TEST_ACCOUNT_ID)
       .build(), collector);
 
     try {

--- a/widgets/MarketingCloud-batchsource.json
+++ b/widgets/MarketingCloud-batchsource.json
@@ -190,6 +190,14 @@
           "widget-attributes" : {
             "placeholder": "Salesforce REST API Endpoint e.g. https://instance.rest.marketingcloudapis.com"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Account ID",
+          "name": "accountId",
+          "widget-attributes": {
+            "placeholder": "Salesforce account ID"
+          }
         }
       ]
     }

--- a/widgets/SalesforceDataExtension-batchsink.json
+++ b/widgets/SalesforceDataExtension-batchsink.json
@@ -64,6 +64,14 @@
           "widget-type": "textbox",
           "label": "SOAP Base URI",
           "name": "soapEndpoint"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Account ID",
+          "name": "accountId",
+          "widget-attributes": {
+            "placeholder": "Salesforce account ID"
+          }
         }
       ]
     },


### PR DESCRIPTION
Without specifying an accountId for the client, we always end up with empty results. This PR adds accountId to the plugin.